### PR TITLE
Fix various Trusted Types violations with use of policy

### DIFF
--- a/packages/next/client/dev/dev-build-watcher.js
+++ b/packages/next/client/dev/dev-build-watcher.js
@@ -1,4 +1,5 @@
 import { addMessageListener } from './error-overlay/websocket'
+import { __unsafeCreateTrustedHTML } from '../trusted-types'
 
 export default function initializeBuildWatcher(
   toggleCallback,
@@ -109,7 +110,7 @@ export default function initializeBuildWatcher(
 function createContainer(prefix) {
   const container = document.createElement('div')
   container.id = `${prefix}container`
-  container.innerHTML = `
+  container.innerHTML = __unsafeCreateTrustedHTML(`
     <div id="${prefix}icon-wrapper">
       <svg viewBox="0 0 226 200">
         <defs>
@@ -129,7 +130,7 @@ function createContainer(prefix) {
         </g>
       </svg>
     </div>
-  `
+  `)
 
   return container
 }

--- a/packages/next/client/trusted-types.ts
+++ b/packages/next/client/trusted-types.ts
@@ -22,6 +22,34 @@ function getPolicy() {
 }
 
 /**
+ * Unsafely promote a string to a TrustedHTML, falling back to strings when
+ * Trusted Types are not available.
+ * This is a security-sensitive function; any use of this function
+ * must go through security review. In particular, it must be assured that the
+ * provided string will never cause an XSS vulnerability if used in a context
+ * that will be interpreted as HTML by a browser, e.g. when assigning to
+ * element.innerHTML.
+ */
+export function __unsafeCreateTrustedHTML(html: string): TrustedHTML | string {
+  return getPolicy()?.createHTML(html) || html
+}
+
+/**
+ * Unsafely promote a string to a TrustedScript, falling back to strings when
+ * Trusted Types are not available.
+ * This is a security-sensitive function; any use of this function
+ * must go through security review. In particular, it must be assured that the
+ * provided string will never cause an XSS vulnerability if used in a context
+ * that will be interpreted and executed as a script by a browser, e.g. when
+ * calling eval.
+ */
+export function __unsafeCreateTrustedScript(
+  script: string
+): TrustedScript | string {
+  return getPolicy()?.createScript(script) || script
+}
+
+/**
  * Unsafely promote a string to a TrustedScriptURL, falling back to strings
  * when Trusted Types are not available.
  * This is a security-sensitive function; any use of this function
@@ -34,4 +62,14 @@ export function __unsafeCreateTrustedScriptURL(
   url: string
 ): TrustedScriptURL | string {
   return getPolicy()?.createScriptURL(url) || url
+}
+
+/**
+ * Returns true if the input is a TrustedScript object, and returns false
+ * otherwise.
+ */
+export function isTrustedScript(script: any): boolean {
+  return (
+    typeof window !== 'undefined' && !!window.trustedTypes?.isScript(script)
+  )
 }

--- a/tsec-exemptions.json
+++ b/tsec-exemptions.json
@@ -1,7 +1,6 @@
 {
   "ban-element-innerhtml-assignments": [
     "packages/next/client/head-manager.ts",
-    "packages/next/client/script.tsx",
     "packages/react-dev-overlay/src/internal/components/Overlay/maintain--tab-focus.ts"
   ],
   "ban-element-setattribute": [


### PR DESCRIPTION
## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation
There are multiple Trusted Types violations that are addressed in this PR:
### head-manager.ts
This file contains 3 potential Trusted Types violations that have been addressed. Most strings passed into the DOM sinks in this file are not promoted to Trusted Types within this PR. The reason behind this is because there is no sanitation of the input being passed to script elements. This means that we want the application to throw Trusted Types violations if application developers are passing unsafe, raw strings to these elements and encourage them to instead pass in Trusted Types objects themselves.

[el.setAttribute(attr, props[p])](https://github.com/jgoping/next.js/blob/canary/packages/next/client/head-manager.ts#L25)
This line can lead to XSS violations if used improperly. For example, if a script tag is within next/head tag that has a user-controlled src, it has the potential to be executed. This line was left alone as it already supports users passing in Trusted Types objects themselves.
```
<script src={"data:,console.log('unsafe src')"} />  // Trusted Types violation
<script
  src={getPolicy()?.createScriptURL("data:,console.log('safe src')")}  // No Trusted Types violation
/>
```

[el.innerHTML = dangerouslySetInnerHTML.__html || ''](https://github.com/jgoping/next.js/blob/canary/packages/next/client/head-manager.ts#L31)
This line was also left for users to pass in their own Trusted Types objects. However, if a user attempts to use dangerouslySetInnerHTML with a script element, it is unavoidable that a Trusted Types error is thrown. This is because the input needs to be passed in as a `TrustedHTML` object, but when it is evaluated it needs to be a `TrustedScript` object. Since users would not be able to avoid this error and the fact that it is generally an unsafe practice, an error is written to the console if someone attempts to do this.
```
<script dangerouslySetInnerHTML={{ __html: "..." }} />  // Writes error to console
```
[el.textContent = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''](https://github.com/jgoping/next.js/blob/canary/packages/next/client/head-manager.ts#L33)
Again, we expect application developers to pass in their own Trusted Types objects here. However, a special case has been added to the code for the scenario where an application developer passes in an array of children. If each of the children are of type `TrustedScript`, then joining the scripts together would still result in a valid `TrustedScript` object. Thus, after joining the stringified versions of the children together, they are promoted back to a `TrustedScript` object.
```
<script>console.log('unsafe child')</script>  // Trusted Types violation
<script>{getPolicy()?.createScript("console.log('safe child')")}</script> // No Trusted Types violation
<script
  children={[
    "console.log('unsafe child 1');",
    "console.log('unsafe child 2');",
  ]}
/>  // Trusted Types violation
<script
  children={[
    getPolicy()?.createScript("console.log('safe child 1');"),
    getPolicy()?.createScript("console.log('safe child 2');"),
  ]}
/>  // No Trusted Types violation
``` 

### script.tsx
This file has the same three violations as the head-manager.ts section which are addressed in the same way. Additionally, there is one extra violation to cover:

[el.src = src](https://github.com/jgoping/next.js/blob/canary/packages/next/client/script.tsx#L90)
This has been left alone as an application developer is able to pass in their own Trusted Types object here. However, this seems to be unnecessary code as the `el.setAttribute(attr, value)` below it does not ignore `src` as an `attr` value, thus from my testing the `src` of the element is assigned to twice. If there is a specific reason this code is required, please let me know, otherwise I believe it should be removed.

### dev-build-watcher.js
This file contained an innerHTML assignment which raised a Trusted Types violation. The only variable used within this string is `prefix`, but since the only possible values for this variable are `''` or `'__next-build-watcher-'`, this string is deemed safe. Thus, the string has been promoted to the type `TrustedHTML` to fix the violation.